### PR TITLE
ci: set read-only workflow token permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 env:
   FOUNDRY_PROFILE: ci
 


### PR DESCRIPTION
## Summary
- set explicit read-only `GITHUB_TOKEN` permissions for CI workflows that only need repository checkout/read access
- leave release/deploy/write-capable workflows unchanged

## Why
This follows GitHub Actions least-privilege guidance and reduces the default token scope available to routine CI jobs without changing the test/build commands.

## Verification
- Parsed the changed workflow YAML with PyYAML.
- Ran `git diff --check`.
